### PR TITLE
Set KIBOT conditionnally in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 #!/usr/bin/make
+
+ifeq ($(KIBOT),)
 KIBOT=kibot
+endif
 DEBUG=
 OUT_DIR=Generated
 


### PR DESCRIPTION
On windows, I used a [wrapper script](https://github.com/INTI-CMNB/kicad_auto/issues/5#issue-1051018841) to launch kicost in docker.

Setting KIBOT conditionnally allows the environment variable KIBOT to be applied without having to set the '-e' option for make.