### PR TITLE
Change to upload-artifact@v2 because v1 is missing required runs.using

### DIFF
--- a/.github/workflows/kibot.yml
+++ b/.github/workflows/kibot.yml
@@ -32,7 +32,7 @@ jobs:
         make erc
 
     - name: Retrieve results
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: ERC_Output
         path: Generated

--- a/ardu_prog.kibot.yaml
+++ b/ardu_prog.kibot.yaml
@@ -144,6 +144,16 @@ outputs:
       format: jpg
       dpi: 300
 
+  - name: board_top_filled
+    comment: "Top layer view with components"
+    type: pcbdraw
+    dir: PCB
+    options:
+      format: jpg
+      dpi: 300
+      show_components: all
+      output: '%f-%i%v-filled.%x'
+
   - name: board_bottom
     comment: "Bottom layer view"
     type: pcbdraw
@@ -153,6 +163,17 @@ outputs:
       dpi: 300
       bottom: true
 
+  - name: board_bottom_filled
+    comment: "Bottom layer view with components"
+    type: pcbdraw
+    dir: PCB
+    options:
+      format: jpg
+      dpi: 300
+      bottom: true
+      show_components: all
+      output: '%f-%i%v-filled.%x'
+      
   - name: 3D
     comment: "STEP 3D model"
     type: step


### PR DESCRIPTION
When running [act](https://github.com/nektos/act), an error in yamlwas revealed.
Solution suggested for another action at https://github.com/nektos/act/issues/322
https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsusing .

This fix lets it proceed further, but I still get another error with regards to node.

If it doesn't work for the github workflow, leave it be - it's just a demo.